### PR TITLE
新增Fleet分布式CTR-DNN示例，同时支持py_reader与dataset读取方式

### DIFF
--- a/examples/distribute_ctr/README.md
+++ b/examples/distribute_ctr/README.md
@@ -1,0 +1,75 @@
+#  CTR-DNN
+
+## 模型简介
+
+论文来源：
+
+>@inproceedings{guo2017deepfm,
+  title={DeepFM: A Factorization-Machine based Neural Network for CTR Prediction},
+  author={Huifeng Guo, Ruiming Tang, Yunming Ye, Zhenguo Li and Xiuqiang He},
+  booktitle={the Twenty-Sixth International Joint Conference on Artificial Intelligence (IJCAI)},
+  pages={1725--1731},
+  year={2017}
+}
+
+模型设计可以参考：
+>https://github.com/PaddlePaddle/models/tree/develop/PaddleRec/ctr
+
+## 使用方法
+该代码库是为了向您提供基于Fleet的分布式Pserver模式使用示例。我们默认使用2X2，即2个PSERVER，2个TRAINER的组网方式进行训练。我们同时支持使用py_reader与Dataset方式进行高效的数据输入。主要组成为：
+
+- 模型部分
+   - model.py
+   - argument.py
+- 数据读取部分
+   - py_reader_generator.py  
+   - dataset_generator.py
+- 分布式运行部分
+   - dist_continuous_envalauation.py 
+- 数据下载及程序入口
+   - local_cluster.sh
+   - get_data.sh
+
+首先进行数据的下载。
+```
+sh get_data.sh
+```
+***
+###### py_reader模式
+
+开启参数服务器
+
+```
+sh local_cluster.sh pyreader ps
+```
+开启TRAINER端进行同步训练
+
+```
+sh local_cluster.sh pyreader tr
+```
+***
+###### Dataset模式
+
+开启参数服务器
+
+
+```
+sh local_cluster.sh dataset ps
+```
+开启TRAINER端进行异步训练
+
+```
+sh local_cluster.sh dataset tr
+```
+
+## 细节说明
+- 训练结束后默认在0号TRAINER开启预测任务
+- 训练过程中的结果记录保存在./result
+- 训练得到的模型保存在./model
+- dataset模式目前仅支持运行在Linux环境下
+- 请确保您的Paddle fluid版本在1.5.0之上
+
+
+
+
+

--- a/examples/distribute_ctr/argument.py
+++ b/examples/distribute_ctr/argument.py
@@ -1,0 +1,157 @@
+#   Copyright (c) 2019 PaddlePaddle Authors. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import argparse
+
+
+def params_args(args=None):
+    """
+    Parse command line arguments
+    Args:
+        args command line arguments or None (default)
+    Returns:
+        dictionary of parameters with argparse class
+    """
+    # parameters of model and files
+    params = argparse.ArgumentParser(
+        description='Run distribute model CE test.')
+    params.add_argument(
+        "--name", type=str, default="ctr-dnn", help="The name of current model")
+    params.add_argument(
+        "--train_files_path",
+        type=str,
+        default="raw_data",
+        help="Data file(s) for training.")
+    params.add_argument(
+        "--test_files_path",
+        type=str,
+        default="test_data",
+        help="Data file(s) for validation or evaluation.")
+    params.add_argument("--log_path", type=str, default="result")
+    params.add_argument("--model_path", type=str, default="model")
+
+    # parameters of training
+    params.add_argument(
+        "-l",
+        "--learning_rate",
+        type=float,
+        default=1e-4,
+        help="Initial learning rate for training.")
+    params.add_argument(
+        "-b",
+        "--batch_size",
+        type=int,
+        default=1000,
+        help="Mini batch size for training.")
+    params.add_argument(
+        "-e",
+        "--epochs",
+        type=int,
+        default=1,
+        help="Number of epochs for training.")
+    params.add_argument(
+        "--decay_steps",
+        type=int,
+        default=2,
+        help="Decay the learning rate after every N epochs.")
+    params.add_argument(
+        "--decay_rate",
+        type=float,
+        default=0.99,
+        help='Rate of decaying the learning rate.')
+    params.add_argument(
+        "--random_seed",
+        type=int,
+        default=0,
+        help="Random seed if need to fix init parameter")
+
+    # customized parameters
+    params.add_argument(
+        '--embedding_size',
+        type=int,
+        default=10,
+        help="The size for embedding layer (default:10)")
+    params.add_argument(
+        '--num_passes',
+        type=int,
+        default=10,
+        help="The number of passes to train (default: 10)")
+    params.add_argument(
+        '--sparse_feature_dim',
+        type=int,
+        default=1000001,
+        help='sparse feature hashing space for index processing')
+    params.add_argument('--dense_feature_dim', type=int, default=13)
+    params.add_argument(
+        '--no_split_var',
+        action='store_true',
+        default=False,
+        help='Whether split variables into blocks when update_method is pserver')
+
+    # parameters of train method
+    params.add_argument("--is_pyreader_train", type=bool, default=False)
+    params.add_argument("--is_dataset_train", type=bool, default=False)
+    params.add_argument(
+        '--is_local',
+        type=int,
+        default=1,
+        help='Local train or distributed train (default: 1)')
+    params.add_argument(
+        '--cloud_train',
+        type=int,
+        default=0,
+        help='Local train or distributed train on paddlecloud (default: 0)')
+
+    # parameters of distribute
+    params.add_argument("--is_distribute", type=bool, default=False)
+    params.add_argument("--is_local_cluster", type=bool, default=False)
+    params.add_argument("--is_sparse", type=bool, default=False)
+    params.add_argument(
+        '-r',
+        "--role",
+        type=str,
+        required=False,
+        choices=['TRAINER', 'PSERVER'])
+    params.add_argument(
+        "--endpoints",
+        type=str,
+        default="",
+        help='The pserver endpoints, like: 127.0.0.1:6000,127.0.0.1:6001')
+    params.add_argument(
+        '--current_endpoint',
+        type=str,
+        default='',
+        help='The path for model to store (default: 127.0.0.1:6000)')
+    params.add_argument(
+        '-i',
+        "--current_id",
+        type=int,
+        default=0,
+        help="Specifies the number of the current role")
+    params.add_argument(
+        "--trainers",
+        type=int,
+        default=1,
+        help="Specify the number of nodes participating in the training")
+    params.add_argument("--is_first_trainer", type=bool, default=False)
+    params.add_argument("--pserver_ip", type=str, default="127.0.0.1")
+    params.add_argument("--pserver_endpoints", type=list, default=[])
+    params.add_argument("--pserver_ports", type=str, default="36001")
+    params.add_argument("--sync_mode", type=bool, default=True)
+    params.add_argument("--async_mode", type=bool, default=False)
+    params.add_argument("--cpu_num", type=int, default=1)
+    params.add_argument("--use_cuda", type=bool, default=False)
+
+    params = params.parse_args()
+    return params

--- a/examples/distribute_ctr/dataset_generator.py
+++ b/examples/distribute_ctr/dataset_generator.py
@@ -1,0 +1,66 @@
+#   Copyright (c) 2019 PaddlePaddle Authors. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import paddle.fluid.incubate.data_generator as dg
+
+cont_min_ = [0, -3, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0]
+cont_max_ = [20, 600, 100, 50, 64000, 500, 100, 50, 500, 10, 10, 10, 50]
+cont_diff_ = [20, 603, 100, 50, 64000, 500, 100, 50, 500, 10, 10, 10, 50]
+hash_dim_ = 1000001
+continuous_range_ = range(1, 14)
+categorical_range_ = range(14, 40)
+
+
+class DacDataset(dg.MultiSlotDataGenerator):
+    """
+    DacDataset: inheritance MultiSlotDataGeneratior, Implement data reading
+    Help document: http://wiki.baidu.com/pages/viewpage.action?pageId=728820675
+    """
+
+    def generate_sample(self, line):
+        """
+        Read the data line by line and process it as a dictionary
+        """
+
+        def reader():
+            """
+            This function needs to be implemented by the user, based on data format
+            """
+            features = line.rstrip('\n').split('\t')
+            dense_feature = []
+            sparse_feature = []
+            for idx in continuous_range_:
+                if features[idx] == "":
+                    dense_feature.append(0.0)
+                else:
+                    dense_feature.append(
+                        (float(features[idx]) - cont_min_[idx - 1]) /
+                        cont_diff_[idx - 1])
+            for idx in categorical_range_:
+                sparse_feature.append(
+                    [hash(str(idx) + features[idx]) % hash_dim_])
+            label = [int(features[0])]
+            process_line = dense_feature, sparse_feature, label
+            feature_name = ["dense_feature"]
+            for idx in categorical_range_:
+                feature_name.append("C" + str(idx - 13))
+            feature_name.append("label")
+
+            yield zip(feature_name, [dense_feature] + sparse_feature + [label])
+
+        return reader
+
+
+d = DacDataset()
+d.run_from_stdin()

--- a/examples/distribute_ctr/dist_continuous_evaluation.py
+++ b/examples/distribute_ctr/dist_continuous_evaluation.py
@@ -221,6 +221,7 @@ class FleetRunnerBase(object):
             for epoch in range(params.epochs):
                 # Notice: py_reader should use try & catch EOFException method to enter the dataset
                 # reader.start() must declare in advance
+                print("Begin pyreader training ...")
                 reader.start()
                 start_time = time.clock()
                 batch_id = 0
@@ -401,15 +402,17 @@ class FleetRunnerBase(object):
 
         if params.is_local_cluster:
             for port in params.pserver_ports.split(","):
+                print("current port: %s"%port)
                 params.pserver_endpoints.append(':'.join(
                     [params.pserver_ip, port]))
+                print("add pserver_endpoint:%s"%(params.pserver_endpoints))
         else:
             for ip in params.pserver_ip.split(","):
                 params.pserver_endpoints.append(':'.join(
                     [ip, params.pserver_ports]))
 
         params.endpoints = ",".join(params.pserver_endpoints)
-        #params.pserver_endpoints = params.endpoints.split(",")
+        print("pserver_endpoints: {}".format(params.pserver_endpoints))
 
         if params.role == "TRAINER" and params.current_id == 0:
             params.is_first_trainer = True

--- a/examples/distribute_ctr/dist_continuous_evaluation.py
+++ b/examples/distribute_ctr/dist_continuous_evaluation.py
@@ -397,7 +397,7 @@ class FleetRunnerBase(object):
         params.current_endpoint = os.getenv(
             "POD_IP", "localhost") + ":" + params.pserver_ports
 
-        params.cpu_num = os.getenv("CPU_NUM")
+        params.cpu_num = int(os.getenv("CPU_NUM"))
         print("output path: {}".format(params.model_path))
 
         if params.is_local_cluster:

--- a/examples/distribute_ctr/dist_continuous_evaluation.py
+++ b/examples/distribute_ctr/dist_continuous_evaluation.py
@@ -76,6 +76,9 @@ class FleetRunnerBase(object):
             server_endpoints=params.pserver_endpoints)
 
         strategy = DistributeTranspilerConfig()
+        if params.is_dataset_train:
+            params.sync_mode=False
+            params.async_mode=True
         strategy.sync_mode = params.sync_mode
         fleet.init(role)
 

--- a/examples/distribute_ctr/dist_continuous_evaluation.py
+++ b/examples/distribute_ctr/dist_continuous_evaluation.py
@@ -1,0 +1,429 @@
+# Copyright (c) 2019 PaddlePaddle Authors. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from __future__ import print_function
+import os
+import time
+import numpy as np
+import paddle
+import paddle.fluid as fluid
+import paddle.fluid.incubate.fleet.base.role_maker as role_maker
+from paddle.fluid.incubate.fleet.parameter_server.distribute_transpiler import fleet
+from paddle.fluid.transpiler.distribute_transpiler import DistributeTranspilerConfig
+import py_reader_generator as py_reader
+
+
+class FleetRunnerBase(object):
+    """
+    Distribute training base class:
+        This class abstracts the training process into several major steps:
+        1. input_data
+        2. net
+        3. run_pserver
+        4. run_trainer
+        5. run_infer
+        6. py_reader
+        7. dataset_reader
+        8. runtime_main
+        ...
+    """
+
+    def input_data(self, params):
+        """
+        Function input_data: Definition of input data format in the network
+        Args:
+            :params: the hyper parameters of network
+        Returns:
+            defined by users
+        """
+        raise NotImplementedError(
+            "input_data should be implemented by child classes.")
+
+    def net(self, inputs, params):
+        """
+        Function net: Definition of network structure
+        Args:
+            :inputs: input data, eg: dataset and labels. defined by funtion: self.input_data
+            :params: the hyper parameters of network
+        Returns:
+            evaluation parameter, defined by users
+        """
+        raise NotImplementedError("net should be implemented by child classes.")
+
+    def run_pserver(self, params):
+        """
+        Function run_pserver: Operation method of parameter server
+        Args
+            :params the hyper parameters of network
+        Returns:
+            None
+        """
+        role = role_maker.UserDefinedRoleMaker(
+            current_id=params.current_id,
+            role=role_maker.Role.SERVER,
+            worker_num=params.trainers,
+            server_endpoints=params.pserver_endpoints)
+
+        strategy = DistributeTranspilerConfig()
+        strategy.sync_mode = params.sync_mode
+        fleet.init(role)
+
+        reader = None
+        inputs = self.input_data(params)
+        feeds = []
+        if params.is_pyreader_train:
+            reader = self.py_reader(params)
+            inputs = fluid.layers.read_file(reader)
+        elif not params.is_dataset_train:
+            raise ValueError(
+                "Program must has Date feed method: is_pyreader_train / is_dataset_train"
+            )
+
+        # For the model: ctr-dnn, we use loss,auc,batch_auc to measure the performance of network
+        # Replace it with your network evaluation index,
+        # Oops, function: self.net don't forget return the input_data, we will use it in function: self.run_infer
+        loss, auc_var, batch_auc_var, _ = self.net(inputs, params)
+
+        # define the optimizer for your model
+        optimizer = fluid.optimizer.Adam(params.learning_rate)
+        optimizer = fleet.distributed_optimizer(optimizer, strategy)
+        optimizer.minimize(loss)
+
+        fleet.init_server()
+        print("PServer init success!")
+        fleet.run_server()
+
+    def run_trainer(self, params):
+        """
+        Function run_trainer: Operation method of training node
+        Args:
+            :params params: the hyper parameters of network
+        Returns
+            :train_result: the dict of training log
+        """
+        print("run trainer")
+
+        role = role_maker.UserDefinedRoleMaker(
+            current_id=params.current_id,
+            role=role_maker.Role.WORKER,
+            worker_num=params.trainers,
+            server_endpoints=params.pserver_endpoints)
+
+        strategy = DistributeTranspilerConfig()
+        if params.is_dataset_train:
+            params.sync_mode=False
+            params.async_mode=True
+        strategy.sync_mode = params.sync_mode
+        fleet.init(role)
+
+        reader = None
+        feeds = []
+        inputs = self.input_data(params)
+        if params.is_pyreader_train:
+            reader = self.py_reader(params)
+            inputs = fluid.layers.read_file(reader)
+        elif not params.is_dataset_train:
+            raise ValueError(
+                "Program must has Date feed method: is_pyreader_train / is_dataset_train"
+            )
+
+        # For the model: ctr-dnn, we use loss,auc,batch_auc to measure the performance of network
+        # Replace it with your network evaluation index,
+        # Oops, function: self.net don't forget return the input_data, we will use it in function: self.run_infer
+        loss, auc_var, batch_auc_var, _ = self.net(inputs, params)
+
+        # define the optimizer for your model
+        optimizer = fluid.optimizer.Adam(params.learning_rate)
+        optimizer = fleet.distributed_optimizer(optimizer, strategy)
+        optimizer.minimize(loss)
+        print("Program construction complete")
+
+        exe = fluid.Executor(fluid.CPUPlace())
+        fleet.init_worker()
+        # No need to exe.run(fluid.default_main_program())
+        exe.run(fleet.startup_program)
+        CPU_NUM = int(params.cpu_num)
+
+        train_result = {}
+
+        # Notice: Both dataset and py_reader method don't using feed={dict} to input data
+        # Paddle Fluid enter data by variable name
+        # When we do the definition of the reader, the program has established the workflow
+        if params.is_dataset_train:
+            print("run dataset train")
+            dataset = self.dataset_reader(inputs, params)
+            file_list = [
+                str(params.train_files_path) + "/%s" % x
+                for x in os.listdir(params.train_files_path)
+            ]
+            if params.is_local_cluster:
+                file_list = fleet.split_files(file_list)
+            print("file list: {}".format(file_list))
+
+            for epoch in range(params.epochs):
+                dataset.set_filelist(file_list)
+                start_time = time.clock()
+
+                # Notice: function train_from_dataset does not return fetch value
+                exe.train_from_dataset(
+                    program=fleet.main_program,
+                    dataset=dataset,
+                    fetch_list=[auc_var],
+                    fetch_info=['auc'],
+                    print_period=10,
+                    debug=False)
+                end_time = time.clock()
+                self.record_time(epoch, train_result, end_time - start_time)
+
+        elif params.is_pyreader_train:
+            train_generator = py_reader.CriteoDataset(params.sparse_feature_dim)
+            file_list = [
+                str(params.train_files_path) + "/%s" % x
+                for x in os.listdir(params.train_files_path)
+            ]
+            print("file list: {}".format(file_list))
+
+            train_reader = paddle.batch(
+                paddle.reader.shuffle(
+                    train_generator.train(file_list, params.trainers,
+                                          params.current_id),
+                    buf_size=params.batch_size * 100),
+                batch_size=params.batch_size)
+            reader.decorate_paddle_reader(train_reader)
+
+            exec_strategy = fluid.ExecutionStrategy()
+            exec_strategy.num_threads = int(params.cpu_num)
+            build_strategy = fluid.BuildStrategy()
+            build_strategy.async_mode = params.async_mode
+            if CPU_NUM > 1:
+                build_strategy.reduce_strategy = fluid.BuildStrategy.ReduceStrategy.Reduce
+
+            compiled_prog = fluid.compiler.CompiledProgram(
+                fleet.main_program).with_data_parallel(
+                    loss_name=loss.name,
+                    build_strategy=build_strategy,
+                    exec_strategy=exec_strategy)
+
+            for epoch in range(params.epochs):
+                # Notice: py_reader should use try & catch EOFException method to enter the dataset
+                # reader.start() must declare in advance
+                reader.start()
+                start_time = time.clock()
+                batch_id = 0
+                try:
+                    while True:
+                        loss_val, auc_val, batch_auc_val = exe.run(
+                            program=compiled_prog,
+                            fetch_list=[
+                                loss.name, auc_var.name, batch_auc_var.name
+                            ])
+                        loss_val = np.mean(loss_val)
+                        auc_val = np.mean(auc_val)
+                        batch_auc_val = np.mean(batch_auc_val)
+                        if batch_id % 10 == 0 and batch_id != 0:
+                            print(
+                                "TRAIN --> pass: {} batch: {} loss: {} auc: {}, batch_auc: {}"
+                                .format(epoch, batch_id, loss_val / params.
+                                        batch_size, auc_val, batch_auc_val))
+                        batch_id += 1
+                except fluid.core.EOFException:
+                    reader.reset()
+
+                end_time = time.clock()
+                train_result = self.record_time(epoch, train_result,
+                                                end_time - start_time)
+
+        train_method = ''
+        if params.is_pyreader_train:
+            train_method = '_pyreader_train'
+        else:
+            train_method = '_dataset_train'
+        log_path = str(params.log_path + '/' + str(params.current_id) +
+                       train_method + '.log')
+        with open(log_path, 'w+') as f:
+            f.write(str(train_result))
+
+        if params.is_first_trainer:
+            model_path = str(params.model_path + '/final' + train_method)
+            fleet.save_persistables(executor=exe, dirname=model_path)
+
+        print("Train Success!")
+        fleet.stop_worker()
+        return train_result
+
+    def run_infer(self, params):
+        """
+        Function run_infer: Operation method of training node
+        Args:
+            :params params: the hyper parameters of network
+        Returns
+            :infer_result, type:dict, record the evalution parameter and program resource usage situation
+        """
+        place = fluid.CPUPlace()
+        inference_scope = fluid.Scope()
+        dataset = py_reader.CriteoDataset(params.sparse_feature_dim)
+        file_list = [
+            str(params.test_files_path) + "/%s" % x
+            for x in os.listdir(params.test_files_path)
+        ]
+        test_reader = paddle.batch(
+            dataset.test(file_list), batch_size=params.batch_size)
+        startup_program = fluid.framework.Program()
+        test_program = fluid.framework.Program()
+
+        def set_zero(var_name):
+            param = inference_scope.var(var_name).get_tensor()
+            param_array = np.zeros(param._get_dims()).astype("int64")
+            param.set(param_array, place)
+
+        with fluid.framework.program_guard(test_program, startup_program):
+            inputs = self.input_data(params)
+            loss, auc_var, batch_auc_var, data_list = self.net(inputs, params)
+
+            exe = fluid.Executor(place)
+            feeder = fluid.DataFeeder(feed_list=data_list, place=place)
+
+            train_method = ''
+            if params.is_pyreader_train:
+                train_method = '_pyreader_train/'
+            else:
+                train_method = '_dataset_train/'
+            model_path = params.model_path + '/final' + train_method
+            fluid.io.load_persistables(
+                executor=exe,
+                dirname=model_path,
+                main_program=fluid.default_main_program())
+
+            auc_states_names = ['_generated_var_2', '_generated_var_3']
+            for name in auc_states_names:
+                set_zero(name)
+
+            run_index = 0
+            L = []
+            A = []
+            for batch_id, data in enumerate(test_reader()):
+                loss_val, auc_val = exe.run(test_program,
+                                            feed=feeder.feed(data),
+                                            fetch_list=[loss, auc_var])
+                run_index += 1
+                L.append(loss_val / params.batch_size)
+                A.append(auc_val)
+                if batch_id % 1000 == 0:
+                    print("TEST --> batch: {} loss: {} auc: {}".format(
+                        batch_id, loss_val / params.batch_size, auc_val))
+
+            infer_loss = np.mean(L)
+            infer_auc = np.mean(A)
+            infer_result = {}
+            infer_result['loss'] = infer_loss
+            infer_result['auc'] = infer_auc
+            log_path = params.log_path + '/infer_result.log'
+            with open(log_path, 'w+') as f:
+                f.write(str(infer_result))
+            print("Inference complete")
+        return infer_result
+
+    def py_reader(self, params):
+        """
+        Function py_reader: define the data read method by fluid.layers.py_reader
+        help: https://www.paddlepaddle.org.cn/documentation/docs/zh/1.5/api_cn/layers_cn/io_cn.html#py-reader
+        Args:
+            :params params: the hyper parameters of network
+        Returns:
+            defined by user
+        """
+        raise NotImplementedError(
+            "py_reader should be implemented by child classes.")
+
+    def dataset_reader(self, inputs, params):
+        """
+        Function dataset_reader: define the data read method by fluid.dataset.DatasetFactory
+        help: https://www.paddlepaddle.org.cn/documentation/docs/zh/1.5/api_cn/dataset_cn.html#fluid-dataset
+        Args:
+            :params inputs: input data, eg: dataset and labels. defined by funtion: self.input_data
+            :params params: the hyper parameters of network
+        Returns:
+            defined by user
+        """
+        raise NotImplementedError(
+            "dataset_reader should be implemented by child classes.")
+
+    def record_time(self, epoch, train_result, time):
+        """
+        record the operation time
+        """
+        train_result[epoch] = {}
+        train_result[epoch]['time'] = time
+        return train_result
+
+    def runtime_main(self, params):
+        """
+        Function runtime_main: the entry point for program running
+        Args:
+            :params params: the hyper parameters of network
+        """
+
+        # Step1: get the environment variable, mainly related to network communication parameters
+        params.role = os.getenv("TRAINING_ROLE")
+        print("Training role: {}".format(params.role))
+
+        params.current_id = int(os.getenv("PADDLE_TRAINER_ID"))
+        print("Current Id: {}".format(params.current_id))
+
+        params.trainers = int(os.getenv("PADDLE_TRAINERS_NUM"))
+        print("Trainer num: {}".format(params.trainers))
+
+        params.pserver_ports = os.getenv("PADDLE_PORT")
+        print("Pserver ports: {}".format(params.pserver_ports))
+
+        params.pserver_ip = os.getenv("PADDLE_PSERVERS")
+        print("Pserver IP: {}".format(params.pserver_ip))
+
+        params.current_endpoint = os.getenv(
+            "POD_IP", "localhost") + ":" + params.pserver_ports
+
+        params.cpu_num = os.getenv("CPU_NUM")
+        print("output path: {}".format(params.model_path))
+
+        if params.is_local_cluster:
+            for port in params.pserver_ports.split(","):
+                params.pserver_endpoints.append(':'.join(
+                    [params.pserver_ip, port]))
+        else:
+            for ip in params.pserver_ip.split(","):
+                params.pserver_endpoints.append(':'.join(
+                    [ip, params.pserver_ports]))
+
+        params.endpoints = ",".join(params.pserver_endpoints)
+        #params.pserver_endpoints = params.endpoints.split(",")
+
+        if params.role == "TRAINER" and params.current_id == 0:
+            params.is_first_trainer = True
+
+        # Step2: According to the parameters-> TRAINING_ROLE, decide which method to run
+        if params.role == "PSERVER":
+            self.run_pserver(params)
+        elif params.role == "TRAINER":
+            self.run_trainer(params)
+        else:
+            raise ValueError(
+                "Please choice training role for current node : PSERVER / TRAINER"
+            )
+
+        # Step3: If the role is first trainer, after training, perform verification on the test data
+        if params.is_first_trainer:
+            infer_result = self.run_infer(params)
+            infer_result_path = "./" + params.log_path + "/infer_result.txt"
+            with open(infer_result_path, 'w') as f:
+                f.writelines(str(infer_result))

--- a/examples/distribute_ctr/get_data.sh
+++ b/examples/distribute_ctr/get_data.sh
@@ -1,0 +1,2 @@
+wget --no-check-certificate https://fleet.bj.bcebos.com/ctr_data.tar.gz
+tar -zxvf ctr_data.tar.gz

--- a/examples/distribute_ctr/local_cluster.sh
+++ b/examples/distribute_ctr/local_cluster.sh
@@ -3,7 +3,7 @@ echo "WARNING: This script only for run PaddlePaddle Fluid on one node"
 echo "Running 2X2 Parameter Server model"
 
 if [ ! -d "./model" ]; then
-  mkdir ./myfolder
+  mkdir ./model
   echo "Create model folder for store infer model"
 fi
 

--- a/examples/distribute_ctr/local_cluster.sh
+++ b/examples/distribute_ctr/local_cluster.sh
@@ -38,20 +38,7 @@ export PADDLE_PSERVER_NUMS=2
 export PADDLE_TRAINERS=2
 
 train_method=$1
-#if [ ${train_method}!="pyreader" -a ${train_method}!="dataset" ]
-#then
-#	echo "train_method is first running parameter"
-#	echo "choose: pyreader / dataset "
-#	exit 1
-#fi
-
 role=$2
-#if [ ${role}!="ps" -a ${role}!="tr" ]
-#then
-#	echo "traing role is second running parameter"
-#	echo "choose: ps / tr"
-#	exit 1
-#fi
 
 if [[ ${role} = "ps" ]]
 then

--- a/examples/distribute_ctr/local_cluster.sh
+++ b/examples/distribute_ctr/local_cluster.sh
@@ -1,0 +1,83 @@
+#!/bin/bash
+echo "WARNING: This script only for run PaddlePaddle Fluid on one node"
+echo "Running 2X2 Parameter Server model"
+
+if [ ! -d "./model" ]; then
+  mkdir ./myfolder
+  echo "Create model folder for store infer model"
+fi
+
+if [ ! -d "./result" ]; then
+  mkdir ./result
+  echo "Create result folder for store training result"
+fi
+
+if [ ! -d "./log" ]; then
+  mkdir ./log
+  echo "Create log floder for store running log"
+fi
+
+# environment variables for fleet distribute training
+export PADDLE_TRAINER_ID=0
+export PADDLE_TRAINERS_NUM=2
+export PADDLE_PORT=36001,36002
+export PADDLE_PSERVERS=127.0.0.1
+export POD_IP=127.0.0.1
+export CPU_NUM=2
+export OUTPUT_PATH="output"
+export SYS_JOB_ID="local_cluster"
+export FLAGS_communicator_send_queue_size=1
+export FLAGS_communicator_thread_pool_size=5
+export FLAGS_communicator_max_merge_var_num=20
+export FLAGS_communicator_fake_rpc=0
+
+export PADDLE_PSERVER_PORTS=36001,36002
+export PADDLE_PSERVER_PORT_ARRAY=(36001 36002)
+
+export PADDLE_PSERVER_NUMS=2
+export PADDLE_TRAINERS=2
+
+train_method=$1
+#if [ ${train_method}!="pyreader" -a ${train_method}!="dataset" ]
+#then
+#	echo "train_method is first running parameter"
+#	echo "choose: pyreader / dataset "
+#	exit 1
+#fi
+
+role=$2
+#if [ ${role}!="ps" -a ${role}!="tr" ]
+#then
+#	echo "traing role is second running parameter"
+#	echo "choose: ps / tr"
+#	exit 1
+#fi
+
+if [[ ${role} = "ps" ]]
+then
+    export TRAINING_ROLE=PSERVER
+    export GLOG_v=0
+    export GLOG_logtostderr=1
+
+    for((i=0;i<$PADDLE_PSERVER_NUMS;i++))
+    do
+        cur_port=${PADDLE_PSERVER_PORT_ARRAY[$i]}
+        echo "PADDLE WILL START PSERVER "$cur_port
+	PADDLE_TRAINER_ID=$i
+	python -u model.py --is_${train_method}_train=True --is_local_cluster=True &> ./log/pserver.$i.log &
+    done
+fi
+
+if [[ ${role} = "tr" ]]
+then
+    export TRAINING_ROLE=TRAINER
+    export GLOG_v=0
+    export GLOG_logtostderr=1
+
+    for((i=0;i<$PADDLE_TRAINERS;i++))
+    do
+        echo "PADDLE WILL START Trainer "$i
+        PADDLE_TRAINER_ID=$i 
+	python -u model.py --is_${train_method}_train=True --is_local_cluster=True &> ./log/trainer.$i.log &
+    done
+fi

--- a/examples/distribute_ctr/model.py
+++ b/examples/distribute_ctr/model.py
@@ -55,8 +55,6 @@ class CTR(FleetRunnerBase):
                 return fluid.layers.embedding(
                     input=input,
                     is_sparse=True,
-                    # you need to patch https://github.com/PaddlePaddle/Paddle/pull/14190
-                    # if you want to set is_distributed to True
                     is_distributed=False,
                     size=[sparse_feature_dim, embedding_size],
                     param_attr=fluid.ParamAttr(

--- a/examples/distribute_ctr/model.py
+++ b/examples/distribute_ctr/model.py
@@ -1,0 +1,127 @@
+#!/usr/bin/python
+# Copyright (c) 2019 PaddlePaddle Authors. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import math
+import paddle.fluid as fluid
+from dist_continuous_evaluation import FleetRunnerBase
+from argument import params_args
+
+
+class CTR(FleetRunnerBase):
+    """
+    DNN for Click-Through Rate prediction
+    help: https://github.com/PaddlePaddle/models/tree/develop/PaddleRec/ctr
+    """
+
+    def input_data(self, params):
+        with fluid.unique_name.guard():
+            dense_feature_dim = params.dense_feature_dim
+            self.dense_input = fluid.layers.data(
+                name="dense_input", shape=[dense_feature_dim], dtype='float32')
+
+            self.sparse_input_ids = [
+                fluid.layers.data(
+                    name="C" + str(i), shape=[1], lod_level=1, dtype='int64')
+                for i in range(1, 27)
+            ]
+
+            self.label = fluid.layers.data(
+                name='label', shape=[1], dtype='int64')
+
+            self._words = [self.dense_input
+                           ] + self.sparse_input_ids + [self.label]
+        return self._words
+
+    def net(self, inputs, params):
+        with fluid.unique_name.guard():
+            sparse_feature_dim = params.sparse_feature_dim
+            embedding_size = params.embedding_size
+
+            words = inputs
+
+            def embedding_layer(input):
+                return fluid.layers.embedding(
+                    input=input,
+                    is_sparse=True,
+                    # you need to patch https://github.com/PaddlePaddle/Paddle/pull/14190
+                    # if you want to set is_distributed to True
+                    is_distributed=False,
+                    size=[sparse_feature_dim, embedding_size],
+                    param_attr=fluid.ParamAttr(
+                        name="SparseFeatFactors",
+                        initializer=fluid.initializer.Uniform()))
+
+            sparse_embed_seq = list(map(embedding_layer, words[1:-1]))
+            concated = fluid.layers.concat(
+                sparse_embed_seq + words[0:1], axis=1)
+
+            fc1 = fluid.layers.fc(
+                input=concated,
+                size=400,
+                act='relu',
+                param_attr=fluid.ParamAttr(initializer=fluid.initializer.Normal(
+                    scale=1 / math.sqrt(concated.shape[1]))))
+            fc2 = fluid.layers.fc(input=fc1,
+                                  size=400,
+                                  act='relu',
+                                  param_attr=fluid.ParamAttr(
+                                      initializer=fluid.initializer.Normal(
+                                          scale=1 / math.sqrt(fc1.shape[1]))))
+            fc3 = fluid.layers.fc(input=fc2,
+                                  size=400,
+                                  act='relu',
+                                  param_attr=fluid.ParamAttr(
+                                      initializer=fluid.initializer.Normal(
+                                          scale=1 / math.sqrt(fc2.shape[1]))))
+            predict = fluid.layers.fc(
+                input=fc3,
+                size=2,
+                act='softmax',
+                param_attr=fluid.ParamAttr(initializer=fluid.initializer.Normal(
+                    scale=1 / math.sqrt(fc3.shape[1]))))
+
+            cost = fluid.layers.cross_entropy(input=predict, label=words[-1])
+            avg_cost = fluid.layers.reduce_sum(cost)
+            accuracy = fluid.layers.accuracy(input=predict, label=words[-1])
+            auc_var, batch_auc_var, auc_states = \
+                fluid.layers.auc(input=predict, label=words[-1], num_thresholds=2 ** 12, slide_steps=20)
+
+        return avg_cost, auc_var, batch_auc_var, words
+
+    def py_reader(self, params):
+        py_reader = fluid.layers.create_py_reader_by_data(
+            capacity=64,
+            feed_list=self._words,
+            name='py_reader',
+            use_double_buffer=True)
+
+        return py_reader
+
+    def dataset_reader(self, inputs, params):
+        dataset = fluid.DatasetFactory().create_dataset()
+        dataset.set_use_var([self.dense_input] + self.sparse_input_ids +
+                            [self.label])
+        pipe_command = "python dataset_generator.py"
+        dataset.set_pipe_command(pipe_command)
+        dataset.set_batch_size(100)
+        thread_num = 10
+        dataset.set_thread(thread_num)
+        return dataset
+
+
+if __name__ == '__main__':
+    params = params_args()
+    model = CTR()
+    model.runtime_main(params)

--- a/examples/distribute_ctr/py_reader_generator.py
+++ b/examples/distribute_ctr/py_reader_generator.py
@@ -25,10 +25,6 @@ class Dataset:
 
 
 class CriteoDataset(Dataset):
-    """
-
-    """
-
     def __init__(self, sparse_feature_dim):
         self.cont_min_ = [0, -3, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0]
         self.cont_max_ = [

--- a/examples/distribute_ctr/py_reader_generator.py
+++ b/examples/distribute_ctr/py_reader_generator.py
@@ -1,0 +1,82 @@
+#!/usr/bin/python
+# Copyright (c) 2019 PaddlePaddle Authors. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# There are 13 integer features and 26 categorical features
+continous_features = range(1, 14)
+categorial_features = range(14, 40)
+continous_clip = [20, 600, 100, 50, 64000, 500, 100, 50, 500, 10, 10, 10, 50]
+
+
+class Dataset:
+    def __init__(self):
+        pass
+
+
+class CriteoDataset(Dataset):
+    """
+
+    """
+
+    def __init__(self, sparse_feature_dim):
+        self.cont_min_ = [0, -3, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0]
+        self.cont_max_ = [
+            20, 600, 100, 50, 64000, 500, 100, 50, 500, 10, 10, 10, 50
+        ]
+        self.cont_diff_ = [
+            20, 603, 100, 50, 64000, 500, 100, 50, 500, 10, 10, 10, 50
+        ]
+        self.hash_dim_ = sparse_feature_dim
+        # here, training data are lines with line_index < train_idx_
+        self.train_idx_ = 41256555
+        self.continuous_range_ = range(1, 14)
+        self.categorical_range_ = range(14, 40)
+
+    def _reader_creator(self, file_list, is_train, trainer_num, trainer_id):
+        def reader():
+            print(file_list)
+            for file in file_list:
+                with open(file, 'r') as f:
+                    print("open file success")
+                    line_idx = 0
+                    for line in f:
+                        line_idx += 1
+                        features = line.rstrip('\n').split('\t')
+                        dense_feature = []
+                        sparse_feature = []
+                        for idx in self.continuous_range_:
+                            if features[idx] == '':
+                                dense_feature.append(0.0)
+                            else:
+                                dense_feature.append((float(features[idx]) -
+                                                      self.cont_min_[idx - 1]) /
+                                                     self.cont_diff_[idx - 1])
+                        for idx in self.categorical_range_:
+                            sparse_feature.append([
+                                hash(str(idx) + features[idx]) % self.hash_dim_
+                            ])
+
+                        label = [int(features[0])]
+                        yield [dense_feature] + sparse_feature + [label]
+
+        return reader
+
+    def train(self, file_list, trainer_num, trainer_id):
+        return self._reader_creator(file_list, True, trainer_num, trainer_id)
+
+    def test(self, file_list):
+        return self._reader_creator(file_list, False, 1, 0)
+
+    def infer(self, file_list):
+        return self._reader_creator(file_list, False, 1, 0)


### PR DESCRIPTION
新增了支持Fleet Pserver分布式方式的CTR模型实现，通过执行local_cluster，可以在本地开启一个2X2的PSERVER-TRAINER组网，进行训练。该模型也支持通过参数 pyreader/dataset 选择不同的数据读取方式。在0号Trainer执行完训练过程后，会自动运行预测，给出模型的精度评价。